### PR TITLE
Give styles an exportable getGeometry method

### DIFF
--- a/src/ol/render/canvas/canvasimmediate.js
+++ b/src/ol/render/canvas/canvasimmediate.js
@@ -477,7 +477,7 @@ ol.render.canvas.Immediate.prototype.drawCircleGeometry =
  * @api
  */
 ol.render.canvas.Immediate.prototype.drawFeature = function(feature, style) {
-  var geometry = style.getGeometryFunction().call(style, feature);
+  var geometry = style.getGeometry(feature);
   if (!goog.isDefAndNotNull(geometry) ||
       !ol.extent.intersects(this.extent_, geometry.getExtent())) {
     return;

--- a/src/ol/render/vector.js
+++ b/src/ol/render/vector.js
@@ -123,7 +123,7 @@ ol.renderer.vector.renderFeature = function(
  */
 ol.renderer.vector.renderFeature_ = function(
     replayGroup, feature, style, squaredTolerance) {
-  var geometry = style.getGeometryFunction().call(style, feature);
+  var geometry = style.getGeometry(feature);
   if (!goog.isDefAndNotNull(geometry)) {
     return;
   }

--- a/src/ol/render/webgl/webglimmediate.js
+++ b/src/ol/render/webgl/webglimmediate.js
@@ -118,7 +118,7 @@ ol.render.webgl.Immediate.prototype.drawCircleGeometry =
  * @api
  */
 ol.render.webgl.Immediate.prototype.drawFeature = function(feature, style) {
-  var geometry = style.getGeometryFunction().call(style, feature);
+  var geometry = style.getGeometry(feature);
   if (!goog.isDefAndNotNull(geometry) ||
       !ol.extent.intersects(this.extent_, geometry.getExtent())) {
     return;

--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -70,12 +70,13 @@ ol.style.Style = function(opt_options) {
 
 
 /**
- * @return {!ol.style.GeometryFunction} Function that
- * is called with a feature and returns the geometry to render instead of the
- * feature's geometry.
+ * Get the geometry to be rendered for the provided feature.
+ * @param {ol.Feature} feature The feature to be rendered.
+ * @return {ol.geom.Geometry|undefined} The geometry to use for rendering.
+ * @api
  */
-ol.style.Style.prototype.getGeometryFunction = function() {
-  return this.geometryFunction_;
+ol.style.Style.prototype.getGeometry = function(feature) {
+  return this.geometryFunction_(feature);
 };
 
 
@@ -138,8 +139,9 @@ ol.style.Style.prototype.setGeometry = function(geometry) {
   } else if (goog.isString(geometry)) {
     this.geometryFunction_ = function(feature) {
       var result = feature.get(geometry);
-      goog.asserts.assert(!goog.isDefAndNotNull(result) ||
-          goog.asserts.assertInstanceof(result, ol.geom.Geometry));
+      if (goog.isDefAndNotNull(result)) {
+        goog.asserts.assertInstanceof(result, ol.geom.Geometry);
+      }
       return result;
     };
   } else if (goog.isDef(geometry)) {
@@ -319,8 +321,7 @@ ol.style.createDefaultEditingStyles = function() {
 
 /**
  * A function that takes an `{ol.Feature}` as argument and returns a geometry
- * that will be rendered and styled for the feature. The `this` keyword inside
- * the function references the style that will be applied to the feature.
+ * that will be rendered and styled for the feature.
  *
  * @typedef {function(ol.Feature): (ol.geom.Geometry|undefined)}
  * @api

--- a/test/spec/ol/style.test.js
+++ b/test/spec/ol/style.test.js
@@ -13,21 +13,22 @@ describe('ol.style.Style', function() {
   });
 
   describe('#setGeometry', function() {
-    var style = new ol.style.Style();
+    var style;
+    beforeEach(function() {
+      style = new ol.style.Style();
+    });
 
     it('creates a geometry function from a string', function() {
       var feature = new ol.Feature();
       feature.set('myGeom', new ol.geom.Point([0, 0]));
       style.setGeometry('myGeom');
-      expect(style.getGeometryFunction().call(style, feature))
-          .to.eql(feature.get('myGeom'));
+      expect(style.getGeometry(feature)).to.eql(feature.get('myGeom'));
     });
 
     it('creates a geometry function from a geometry', function() {
       var geom = new ol.geom.Point([0, 0]);
       style.setGeometry(geom);
-      expect(style.getGeometryFunction().call(style))
-          .to.eql(geom);
+      expect(style.getGeometry()).to.eql(geom);
     });
 
     it('returns the configured geometry function', function() {
@@ -35,9 +36,68 @@ describe('ol.style.Style', function() {
       style.setGeometry(function() {
         return geom;
       });
-      expect(style.getGeometryFunction().call(style))
-          .to.eql(geom);
+      expect(style.getGeometry()).to.eql(geom);
     });
+  });
+
+  describe('#getGeometry', function() {
+
+    it('calls feature.getGeometry() by default', function() {
+      var feature = new ol.Feature();
+      sinon.spy(feature, 'getGeometry');
+
+      var style = new ol.style.Style();
+      var got = style.getGeometry(feature);
+
+      expect(got).to.be(undefined);
+      expect(feature.getGeometry.calledOnce).to.be(true);
+    });
+
+    it('returns a geometry instance set on style', function() {
+      var point = new ol.geom.Point([0, 0]);
+      var feature = new ol.Feature();
+
+      var style = new ol.style.Style({
+        geometry: point
+      });
+      var got = style.getGeometry(feature);
+
+      expect(got).to.be(point);
+    });
+
+    it('can return an alternate geometry property', function() {
+      var defaultGeom = new ol.geom.Point([0, 0]);
+      var altGeom = new ol.geom.Point([1, 1]);
+
+      var feature = new ol.Feature(defaultGeom);
+      feature.set('alt', altGeom);
+
+      var style = new ol.style.Style({
+        geometry: 'alt'
+      });
+      var got = style.getGeometry(feature);
+
+      expect(got).to.be(altGeom);
+    });
+
+    it('calls a user provided geometry getter', function() {
+      var point = new ol.geom.Point([0, 0]);
+      var feature = new ol.Feature();
+
+      var getter = sinon.spy(function(feature) {
+        return point;
+      });
+
+      var style = new ol.style.Style({
+        geometry: getter
+      });
+      var got = style.getGeometry(feature);
+
+      expect(got).to.be(point);
+      expect(getter.calledOnce).to.be(true);
+      expect(getter.calledOn(style)).to.be(true);
+    });
+
   });
 
 });


### PR DESCRIPTION
I think this makes the use of the geometry functions more natural.  E.g.

``` js
var geometry = style.getGeometry(feature);
```

instead of

``` js
var geometry = style.getGeometryFunction().call(style, feature);
```

I've also made the `style.getGeometry()` method exportable so it can be used outside the library (as with the other style methods).

Though we don't depend on it internally, as the tests demonstrate, `style.getGeometry()` calls any custom geometry getter with `this` set to `style` by default (by nature of the syntax, not with an explicit call to `call`).  Users may provide a getter function that has a different `this` object bound.
